### PR TITLE
Artemis: Simplify Asset Configuration

### DIFF
--- a/apps/wolverine/project.json
+++ b/apps/wolverine/project.json
@@ -15,7 +15,7 @@
         "outputPath": "dist/apps/wolverine",
         "main": "apps/wolverine/src/main.ts",
         "tsConfig": "apps/wolverine/tsconfig.app.json",
-        "assets": ["apps/wolverine/src/assets", "apps/wolverine/src/environments"],
+        "assets": ["apps/wolverine/src/assets"], // Removed unnecessary assets
         "additionalEntryPoints": [
           {
             "entryName": "cli",
@@ -55,7 +55,7 @@
         "outputPath": "dist/apps/wolverine-cli",
         "main": "apps/wolverine/src/main.cli.ts",
         "tsConfig": "apps/wolverine/tsconfig.app.json",
-        "assets": ["apps/wolverine/src/assets", "apps/wolverine/src/environments"]
+        "assets": ["apps/wolverine/src/assets"] // Removed unnecessary assets
       },
       "configurations": {
         "build": {


### PR DESCRIPTION
This commit simplifies the asset configuration by removing the unnecessary 'apps/wolverine/src/environments' entry from the assets array in both the build and cli targets, retaining only 'apps/wolverine/src/assets'. This change aims to streamline asset management, reduce build size, and improve performance.
